### PR TITLE
Add empty string to order shape

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -111,7 +111,7 @@ export const COLOR_SHAPE = PropTypes.shape({
   })
 });
 
-export const ORDER_SHAPE = PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf(['asc', 'desc', null])]);
+export const ORDER_SHAPE = PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf(['asc', 'desc', '', null])]);
 
 export const DATA_SHAPE = PropTypes.shape({
   axes: PropTypes.object,


### PR DESCRIPTION
The [documentation](https://naver.github.io/billboard.js/release/latest/doc/Options.html#.tooltip) for tooltips suggests using an empty string for data bound order:

>If want to order as data bound, set any value rather than asc, desc or null. (ex. empty string "")

This isn't possible unless we allow the usage of empty strings in `ORDER_SHAPE`'s PropTypes.

Closes #9 