### PR TITLE
Add missing label options to shape

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -12,11 +12,13 @@ export const LABEL_SHAPE = PropTypes.oneOfType([
       'inner-bottom',
       'inner-center',
       'inner-left',
+      'inner-middle',
       'inner-right',
       'inner-top',
       'outer-bottom',
       'outer-center',
       'outer-left',
+      'outer-middle',
       'outer-right',
       'outer-top'
     ]),


### PR DESCRIPTION
The definition of the shape for labels was missing `'outer-middle'` and `'inner-middle'` ([See Billboard Docs](https://naver.github.io/billboard.js/release/latest/doc/Options.html#.axis%25E2%2580%25A4x%25E2%2580%25A4label)).

This adds them. (Hope it's ok that I skip creating an issue for this, since it would contain exactly the same information 😉)