### PR TITLE
Region shape should allow strings for start and end

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -366,8 +366,8 @@ export const POINT_SHAPE = PropTypes.shape({
 export const REGION_SHAPE = PropTypes.shape({
   axis: PropTypes.string,
   class: PropTypes.string,
-  end: PropTypes.number,
-  start: PropTypes.number
+  end: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  start: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 });
 
 export const RESIZE_SHAPE = PropTypes.shape({


### PR DESCRIPTION
Start and end should allow for strings. For example, see the TimeSeries chart with regions. https://naver.github.io/billboard.js/demo/#Region.RegionWithTimeseries