### PR TITLE
Fix PropType of axis.x.tick.format: Should support string.

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -68,7 +68,7 @@ export const AXIS_SHAPE = PropTypes.shape({
       culling: PropTypes.bool,
       cullingMax: PropTypes.number,
       fit: PropTypes.bool,
-      format: PropTypes.func,
+      format: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       multiline: PropTypes.bool,
       outer: PropTypes.bool,
       rotate: PropTypes.number,


### PR DESCRIPTION
It's not well-documented, but string format is also supported. See https://naver.github.io/billboard.js/release/latest/doc/Options.html#.axis%25E2%2580%25A4x%25E2%2580%25A4tick%25E2%2580%25A4format

```
A function to format tick value. *Format string is also available for timeseries data.*
```