### PR TITLE
Add new Proptypes based on the Billboard JS API

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -43,7 +43,7 @@ export const AXIS_TICK_SHAPE = PropTypes.shape({
       y: PropTypes.number,
     }),
   }),
-  values: PropTypes.arrayOf(PropTypes.number),
+  values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
 });
 
 export const AXIS_SHAPE = PropTypes.shape({
@@ -73,7 +73,7 @@ export const AXIS_SHAPE = PropTypes.shape({
       outer: PropTypes.bool,
       rotate: PropTypes.number,
       tooltip: PropTypes.bool,
-      values: PropTypes.arrayOf(PropTypes.number),
+      values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
       width: PropTypes.number,
     }),
     type: AXIS_TYPE_SHAPE,
@@ -288,7 +288,7 @@ export const LINES_SHAPE = PropTypes.oneOfType([
       class: PropTypes.string,
       position: PropTypes.string,
       text: PropTypes.string,
-      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]),
     })
   ),
   PropTypes.bool,
@@ -378,7 +378,7 @@ export const POINT_SHAPE = PropTypes.shape({
   focus: PropTypes.shape({
     expand: PropTypes.shape({
       enabled: PropTypes.bool,
-      r: PropTypes.bool,
+      r: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
     }),
   }),
   r: PropTypes.number,

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -43,7 +43,7 @@ export const AXIS_TICK_SHAPE = PropTypes.shape({
       y: PropTypes.number,
     }),
   }),
-  values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
+  values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)])),
 });
 
 export const AXIS_SHAPE = PropTypes.shape({
@@ -73,7 +73,7 @@ export const AXIS_SHAPE = PropTypes.shape({
       outer: PropTypes.bool,
       rotate: PropTypes.number,
       tooltip: PropTypes.bool,
-      values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.object])),
+      values: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date)])),
       width: PropTypes.number,
     }),
     type: AXIS_TYPE_SHAPE,
@@ -288,7 +288,7 @@ export const LINES_SHAPE = PropTypes.oneOfType([
       class: PropTypes.string,
       position: PropTypes.string,
       text: PropTypes.string,
-      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]),
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]),
     })
   ),
   PropTypes.bool,


### PR DESCRIPTION
Hey @planttheidea, how are you?

I was using pure Billboard and decided to use **react-billboardjs** but came across some **invalid props errors** on the console. I'm sending this PR to fix PropTypes errors, this is nothing that Billboard has not implemented yet, the Billboard API already allows you to enter these values. I am putting below an example of how I am using:

```
<BillboardChart
	axis={{
		x: {
		tick: {
			values: [new Date(), new Date()],
		},
		},
	}}
	data={this.state.data}
	grid={{
		lines: {
		front: false,
		},
		x: {
		lines: [{value: new Date()}, {value: new Date()}],
		},
	}}
	isPure
	point={{
		focus: {
		expand: {
			r: 5,
		},
		},
	}}
	ref={this.getRef}
	subchart={SUBCHART}
/>
```

Let me know if you need anything to reproduce the errors