### PR TITLE
change the PropTypes declaration for axis.x.tick.culling

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -65,8 +65,12 @@ export const AXIS_SHAPE = PropTypes.shape({
     tick: PropTypes.shape({
       centered: PropTypes.bool,
       count: PropTypes.number,
-      culling: PropTypes.bool,
-      cullingMax: PropTypes.number,
+      culling: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.shape({
+          max: PropTypes.number,
+        }),
+      ]),
       fit: PropTypes.bool,
       format: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
       multiline: PropTypes.bool,


### PR DESCRIPTION
- Convert `culling` to be one of two types:
  - number
  - shape of `{ max: number }`
- Remove `cullingMax`

Should fix #28 