### PR TITLE
Issue 40 incorrect version check

### DIFF
--- a/src/BillboardChart.js
+++ b/src/BillboardChart.js
@@ -93,10 +93,10 @@ export const componentWillUpdate = ({ updateChart }, [nextProps]) =>
  * @function getSnapshotBeforeUpdate
  *
  * @description
- * when the component will update, update the chart with the new props
+ * prior to the component update, update the chart with the new props
  *
+ * @param {Object} props the just-updated props
  * @param {function} updateChart the method to update the chart
- * @param {Object} nextProps the next props
  * @returns {void}
  */
 export const getSnapshotBeforeUpdate = ({ props, updateChart }) =>

--- a/src/BillboardChart.js
+++ b/src/BillboardChart.js
@@ -38,8 +38,10 @@ const [MAJOR_VERSION, MINOR_VERSION] = React.version
   .split('.')
   .map((section) => parseInt(section, 10));
 
-const COMPONENT_WILL_UPDATE_NAME =
-  MAJOR_VERSION >= 16 && MINOR_VERSION >= 3 ? 'UNSAFE_componentWillUpdate' : 'componentWillUpdate';
+const BEFORE_UPDATE_NAME =
+  MAJOR_VERSION > 16 || (MAJOR_VERSION === 16 && MINOR_VERSION >= 3)
+    ? 'getSnapshotBeforeUpdate'
+    : 'beforeUpdate';
 
 /** 
  * @function componentDidMount 
@@ -68,11 +70,16 @@ export const componentDidMount = ({ props, updateChart }) =>
  * @returns {boolean} should the component update
  */
 
-export const shouldComponentUpdate = ({ context, props }, [nextProps, , nextContext]) =>
-  nextProps.isPure ? !shallowEqual(props, nextProps) || !shallowEqual(context, nextContext) : true;
+export const shouldComponentUpdate = (
+  { context, props },
+  [nextProps, , nextContext]
+) =>
+  nextProps.isPure
+    ? !shallowEqual(props, nextProps) || !shallowEqual(context, nextContext)
+    : true;
 
 /**
- * @function componentWillUpdate
+ * @function beforeUpdate
  *
  * @description
  * when the component will update, update the chart with the new props
@@ -81,7 +88,8 @@ export const shouldComponentUpdate = ({ context, props }, [nextProps, , nextCont
  * @param {Object} nextProps the next props
  * @returns {void}
  */
-export const componentWillUpdate = ({ updateChart }, [nextProps]) => updateChart(nextProps);
+export const beforeUpdate = ({ updateChart }, [nextProps]) =>
+  updateChart(nextProps);
 
 /**
  * @function componentWillUnmount
@@ -291,7 +299,7 @@ BillboardChart.defaultProps = {
 BillboardChart.getInstances = getInstances;
 
 export default createComponent(BillboardChart, {
-  [COMPONENT_WILL_UPDATE_NAME]: componentWillUpdate,
+  [BEFORE_UPDATE_NAME]: beforeUpdate,
   chart: null,
   chartElement: null,
   componentDidMount,

--- a/src/BillboardChart.js
+++ b/src/BillboardChart.js
@@ -38,10 +38,8 @@ const [MAJOR_VERSION, MINOR_VERSION] = React.version
   .split('.')
   .map((section) => parseInt(section, 10));
 
-const BEFORE_UPDATE_NAME =
-  MAJOR_VERSION > 16 || (MAJOR_VERSION === 16 && MINOR_VERSION >= 3)
-    ? 'getSnapshotBeforeUpdate'
-    : 'beforeUpdate';
+const CAN_GET_SNAPSHOT_BEFORE_UPDATE =
+  MAJOR_VERSION > 16 || (MAJOR_VERSION === 16 && MINOR_VERSION >= 3);
 
 /** 
  * @function componentDidMount 
@@ -79,7 +77,7 @@ export const shouldComponentUpdate = (
     : true;
 
 /**
- * @function beforeUpdate
+ * @function componentWillUpdate
  *
  * @description
  * when the component will update, update the chart with the new props
@@ -88,8 +86,21 @@ export const shouldComponentUpdate = (
  * @param {Object} nextProps the next props
  * @returns {void}
  */
-export const beforeUpdate = ({ updateChart }, [nextProps]) =>
+export const componentWillUpdate = ({ updateChart }, [nextProps]) =>
   updateChart(nextProps);
+
+/**
+ * @function getSnapshotBeforeUpdate
+ *
+ * @description
+ * when the component will update, update the chart with the new props
+ *
+ * @param {function} updateChart the method to update the chart
+ * @param {Object} nextProps the next props
+ * @returns {void}
+ */
+export const getSnapshotBeforeUpdate = ({ props, updateChart }) =>
+  updateChart(props);
 
 /**
  * @function componentWillUnmount
@@ -298,8 +309,7 @@ BillboardChart.defaultProps = {
 
 BillboardChart.getInstances = getInstances;
 
-export default createComponent(BillboardChart, {
-  [BEFORE_UPDATE_NAME]: beforeUpdate,
+const schema = {
   chart: null,
   chartElement: null,
   componentDidMount,
@@ -313,4 +323,12 @@ export default createComponent(BillboardChart, {
   shouldComponentUpdate,
   unloadData,
   updateChart,
-});
+};
+
+if (CAN_GET_SNAPSHOT_BEFORE_UPDATE) {
+  schema.getSnapshotBeforeUpdate = getSnapshotBeforeUpdate;
+} else {
+  schema.componentWillUpdate = componentWillUpdate;
+}
+
+export default createComponent(BillboardChart, schema);

--- a/test/BillboardChart.js
+++ b/test/BillboardChart.js
@@ -37,11 +37,15 @@ test('if shouldComponentUpdate will return true if not pure', (t) => {
     },
   };
 
-  const nextProps = {...instance.props};
+  const nextProps = { ...instance.props };
   const nextState = null;
   const nextContext = {};
 
-  const result = component.shouldComponentUpdate(instance, [nextProps, nextState, nextContext]);
+  const result = component.shouldComponentUpdate(instance, [
+    nextProps,
+    nextState,
+    nextContext,
+  ]);
 
   t.true(result);
 });
@@ -54,11 +58,15 @@ test('if shouldComponentUpdate will return true if pure and props are not equal'
     },
   };
 
-  const nextProps = {...instance.props, className: 'foo'};
+  const nextProps = { ...instance.props, className: 'foo' };
   const nextState = null;
   const nextContext = {};
 
-  const result = component.shouldComponentUpdate(instance, [nextProps, nextState, nextContext]);
+  const result = component.shouldComponentUpdate(instance, [
+    nextProps,
+    nextState,
+    nextContext,
+  ]);
 
   t.true(result);
 });
@@ -71,11 +79,15 @@ test('if shouldComponentUpdate will return true if pure and context is not equal
     },
   };
 
-  const nextProps = {...instance.props};
+  const nextProps = { ...instance.props };
   const nextState = null;
-  const nextContext = {apiKey: 'apiKey'};
+  const nextContext = { apiKey: 'apiKey' };
 
-  const result = component.shouldComponentUpdate(instance, [nextProps, nextState, nextContext]);
+  const result = component.shouldComponentUpdate(instance, [
+    nextProps,
+    nextState,
+    nextContext,
+  ]);
 
   t.true(result);
 });
@@ -88,17 +100,36 @@ test('if shouldComponentUpdate will return false if pure and props / context are
     },
   };
 
-  const nextProps = {...instance.props};
+  const nextProps = { ...instance.props };
   const nextState = null;
-  const nextContext = {...instance.context};
+  const nextContext = { ...instance.context };
 
-  const result = component.shouldComponentUpdate(instance, [nextProps, nextState, nextContext]);
+  const result = component.shouldComponentUpdate(instance, [
+    nextProps,
+    nextState,
+    nextContext,
+  ]);
 
   t.false(result);
 });
 
+test('if getSnapshotBeforeUpdate will update the chart with next props', (t) => {
+  const instance = {
+    props: {},
+    updateChart: sinon.spy(),
+  };
+
+  const prevProps = {};
+
+  component.getSnapshotBeforeUpdate(instance, [prevProps]);
+
+  t.true(instance.updateChart.calledOnce);
+  t.true(instance.updateChart.calledWith(instance.props));
+});
+
 test('if componentWillUpdate will update the chart with nextProps', (t) => {
   const instance = {
+    props: {},
     updateChart: sinon.spy(),
   };
 
@@ -216,35 +247,40 @@ test('if exportChart will not call export if the chart does not exist', (t) => {
   });
 });
 
-test.serial('if generateChart will call generate on bb with the config stripped of extra props', (t) => {
-  const instance = {
-    chartElement: {
-      chart: 'element',
-    },
-    props: {
-      className: 'className',
-      config: 'value',
-      isPure: false,
-      style: {},
-      unloadBeforeLoad: false,
-    },
-  };
+test.serial(
+  'if generateChart will call generate on bb with the config stripped of extra props',
+  (t) => {
+    const instance = {
+      chartElement: {
+        chart: 'element',
+      },
+      props: {
+        className: 'className',
+        config: 'value',
+        isPure: false,
+        style: {},
+        unloadBeforeLoad: false,
+      },
+    };
 
-  const fakeBb = {
-    generate: sinon.spy(),
-  };
+    const fakeBb = {
+      generate: sinon.spy(),
+    };
 
-  const bbStub = sinon.stub(bb, 'default').returns(fakeBb);
+    const bbStub = sinon.stub(bb, 'default').returns(fakeBb);
 
-  component.generateChart(instance);
+    component.generateChart(instance);
 
-  t.true(bbStub.calledOnce);
+    t.true(bbStub.calledOnce);
 
-  t.true(fakeBb.generate.calledOnce);
-  t.deepEqual(fakeBb.generate.args[0], [{bindto: instance.chartElement, config: instance.props.config}]);
+    t.true(fakeBb.generate.calledOnce);
+    t.deepEqual(fakeBb.generate.args[0], [
+      { bindto: instance.chartElement, config: instance.props.config },
+    ]);
 
-  bbStub.restore();
-});
+    bbStub.restore();
+  }
+);
 
 test('if loadData will do nothing if the chart does not exist', (t) => {
   const instance = {
@@ -402,138 +438,158 @@ test('if updateChart will unload the data if unloadBeforeLoad is set to true', (
   t.is(instance.chart, chart);
 
   t.true(instance.loadData.calledOnce);
-  t.true(instance.loadData.calledWith({...props.data, unload: props.unloadBeforeLoad}));
+  t.true(
+    instance.loadData.calledWith({
+      ...props.data,
+      unload: props.unloadBeforeLoad,
+    })
+  );
 });
 
-test.serial('if BillboardChart renders correctly with default props', async (t) => {
-  const props = {
-    data: {},
-  };
+test.serial(
+  'if BillboardChart renders correctly with default props',
+  async (t) => {
+    const props = {
+      data: {},
+    };
 
-  const chart = {
-    load: sinon.spy(),
-  };
+    const chart = {
+      load: sinon.spy(),
+    };
 
-  const bbStub = {
-    generate() {
-      return chart;
-    },
-  };
+    const bbStub = {
+      generate() {
+        return chart;
+      },
+    };
 
-  const stub = sinon.stub(bb, 'default').returns(bbStub);
+    const stub = sinon.stub(bb, 'default').returns(bbStub);
 
-  const wrapper = shallow(<BillboardChart {...props} />);
+    const wrapper = shallow(<BillboardChart {...props} />);
 
-  t.snapshot(toJson(wrapper));
+    t.snapshot(toJson(wrapper));
 
-  await nextFrame();
+    await nextFrame();
 
-  t.true(stub.calledOnce);
+    t.true(stub.calledOnce);
 
-  stub.restore();
-});
+    stub.restore();
+  }
+);
 
-test.serial('if BillboardChart renders correctly with a custom className', async (t) => {
-  const props = {
-    className: 'className',
-    data: {},
-  };
+test.serial(
+  'if BillboardChart renders correctly with a custom className',
+  async (t) => {
+    const props = {
+      className: 'className',
+      data: {},
+    };
 
-  const chart = {
-    load: sinon.spy(),
-  };
+    const chart = {
+      load: sinon.spy(),
+    };
 
-  const bbStub = {
-    generate() {
-      return chart;
-    },
-  };
+    const bbStub = {
+      generate() {
+        return chart;
+      },
+    };
 
-  const stub = sinon.stub(bb, 'default').returns(bbStub);
+    const stub = sinon.stub(bb, 'default').returns(bbStub);
 
-  const wrapper = shallow(<BillboardChart {...props} />);
+    const wrapper = shallow(<BillboardChart {...props} />);
 
-  t.snapshot(toJson(wrapper));
+    t.snapshot(toJson(wrapper));
 
-  await nextFrame();
+    await nextFrame();
 
-  t.true(stub.calledOnce);
+    t.true(stub.calledOnce);
 
-  stub.restore();
-});
+    stub.restore();
+  }
+);
 
-test.serial('if BillboardChart renders correctly with a custom style object', async (t) => {
-  const props = {
-    data: {},
-    style: {
-      display: 'inline-block',
-    },
-  };
+test.serial(
+  'if BillboardChart renders correctly with a custom style object',
+  async (t) => {
+    const props = {
+      data: {},
+      style: {
+        display: 'inline-block',
+      },
+    };
 
-  const chart = {
-    load: sinon.spy(),
-  };
+    const chart = {
+      load: sinon.spy(),
+    };
 
-  const bbStub = {
-    generate() {
-      return chart;
-    },
-  };
+    const bbStub = {
+      generate() {
+        return chart;
+      },
+    };
 
-  const stub = sinon.stub(bb, 'default').returns(bbStub);
+    const stub = sinon.stub(bb, 'default').returns(bbStub);
 
-  const wrapper = shallow(<BillboardChart {...props} />);
+    const wrapper = shallow(<BillboardChart {...props} />);
 
-  t.snapshot(toJson(wrapper));
+    t.snapshot(toJson(wrapper));
 
-  await nextFrame();
+    await nextFrame();
 
-  t.true(stub.calledOnce);
+    t.true(stub.calledOnce);
 
-  stub.restore();
-});
+    stub.restore();
+  }
+);
 
-test.serial('if BillboardChart renders correctly with custom domProps passed', async (t) => {
-  const props = {
-    data: {},
-    domProps: {
-      'data-foo': 'bar',
-    },
-  };
+test.serial(
+  'if BillboardChart renders correctly with custom domProps passed',
+  async (t) => {
+    const props = {
+      data: {},
+      domProps: {
+        'data-foo': 'bar',
+      },
+    };
 
-  const chart = {
-    load: sinon.spy(),
-  };
+    const chart = {
+      load: sinon.spy(),
+    };
 
-  const bbStub = {
-    generate() {
-      return chart;
-    },
-  };
+    const bbStub = {
+      generate() {
+        return chart;
+      },
+    };
 
-  const stub = sinon.stub(bb, 'default').returns(bbStub);
+    const stub = sinon.stub(bb, 'default').returns(bbStub);
 
-  const wrapper = shallow(<BillboardChart {...props} />);
+    const wrapper = shallow(<BillboardChart {...props} />);
 
-  t.snapshot(toJson(wrapper));
+    t.snapshot(toJson(wrapper));
 
-  await nextFrame();
+    await nextFrame();
 
-  t.true(stub.calledOnce);
+    t.true(stub.calledOnce);
 
-  stub.restore();
-});
+    stub.restore();
+  }
+);
 
-test.serial('if BillboardChart has a static method that returns the array of instances from the bb object', (t) => {
-  const instance = ['foo', 'bar'];
+test.serial(
+  'if BillboardChart has a static method that returns the array of instances from the bb object',
+  (t) => {
+    const instance = ['foo', 'bar'];
 
-  const stub = sinon.stub(bb, 'default').returns({
-    instance,
-  });
+    const stub = sinon.stub(bb, 'default').returns({
+      instance,
+    });
 
-  const result = BillboardChart.getInstances();
+    const result = BillboardChart.getInstances();
 
-  t.is(result, instance);
+    t.is(result, instance);
 
-  stub.restore();
-});
+    stub.restore();
+  }
+);

--- a/test/BillboardChart.js
+++ b/test/BillboardChart.js
@@ -113,7 +113,7 @@ test('if shouldComponentUpdate will return false if pure and props / context are
   t.false(result);
 });
 
-test('if getSnapshotBeforeUpdate will update the chart with next props', (t) => {
+test('if getSnapshotBeforeUpdate will update the chart with now-updated props', (t) => {
   const instance = {
     props: {},
     updateChart: sinon.spy(),


### PR DESCRIPTION
Should resolve #40 

The change updates the version validator to work for React version 17 and replace the use of `UNSAFE_componentWillReceiveProps` with `getSnapshotBeforeUpdate` to avoid complains about the former's use in `StrictMode`.