### PR TITLE
fix build setup to be split based on environments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,16 @@
       ]
     },
     "production": {
-      "plugins": ["babel-plugin-transform-react-remove-prop-types"]
+      "plugins": [
+        "babel-plugin-transform-react-remove-prop-types",
+        [
+          "babel-plugin-transform-rename-import",
+          {
+            "original": "./propTypes",
+            "replacement": "./propTypes-prod"
+          }
+        ]
+      ]
     },
     "test": {
       "presets": [

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _This is based on [react-c3js](https://github.com/bcbcarl/react-c3js), with modi
 - [react-billboardjs](#react-billboardjs)
   - [Installation](#installation)
   - [Usage](#usage)
+    - [Production usage](#production-usage)
   - [Required props](#required-props)
     - [data](#data)
   - [Optional props](#optional-props)
@@ -65,6 +66,26 @@ class LineChart extends Component {
 ```
 
 Make sure to include the CSS file provided with `billboard.js` to include appropriate styles for billboard. The example above is if you are using `webpack` or a similar bundler, but the styles are global so bring them in however is best for your application.
+
+### Production usage
+
+The `PropTypes` of this package are quite large, as they try to be comprehensive coverage for the configuration of `billboard.js`. If you do not want to incur this cost in production, then you can point your package to the `min` build which excludes them. Example in a webpack config:
+
+```js
+module.exports = {
+  // ...config
+  resolve: {
+    alias: {
+      'react-billboardjs': path.resolve(
+        __dirname, // assuming config is top of the directory
+        'node_modules/react-billboardjs/dist/react-billboardjs.min.js',
+      ),
+    },
+  },
+};
+```
+
+This creates a much smaller bundle, as the minified + gzipped size of `react-billboardjs` drops from 4.51KiB to 1.39KiB.
 
 ## Required props
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   },
   "repository": "git@github.com:planttheidea/react-billboardjs.git",
   "scripts": {
-    "build": "rollup -c",
+    "build": "npm run build:development && npm run build:production",
+    "build:development": "rollup -c",
+    "build:production": "rollup -c --environment NODE_ENV:production",
     "clean": "rimraf dist",
     "dev": "NODE_ENV=development webpack-dev-server --progress --colors",
     "lint": "eslint src/*.js",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
+    "babel-plugin-transform-rename-import": "^2.3.0",
     "css-loader": "^2.1.1",
     "eslint": "^5.16.0",
     "eslint-friendly-formatter": "^4.0.1",
@@ -66,8 +67,8 @@
   "repository": "git@github.com:planttheidea/react-billboardjs.git",
   "scripts": {
     "build": "npm run build:development && npm run build:production",
-    "build:development": "rollup -c",
-    "build:production": "rollup -c --environment NODE_ENV:production",
+    "build:development": "rollup --config rollup.config.js --environment NODE_ENV:development",
+    "build:production": "rollup --config rollup.config.prod.js --environment NODE_ENV:production",
     "clean": "rimraf dist",
     "dev": "NODE_ENV=development webpack-dev-server --progress --colors",
     "lint": "eslint src/*.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import babel from '@rollup/plugin-babel';
-import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 
 const EXTERNALS = [
@@ -7,7 +6,7 @@ const EXTERNALS = [
   ...Object.keys(pkg.peerDependencies || {}),
 ];
 
-const DEFAULT_OUTPUT = {
+export const DEFAULT_OUTPUT = {
   exports: 'named',
   globals: {
     'billboard.js': 'billboard',
@@ -18,7 +17,7 @@ const DEFAULT_OUTPUT = {
   sourcemap: true,
 };
 
-const DEFAULT_CONFIG = {
+export const DEFAULT_CONFIG = {
   external: EXTERNALS,
   input: 'src/index.js',
   output: [
@@ -35,15 +34,4 @@ const DEFAULT_CONFIG = {
   ],
 };
 
-export default [
-  DEFAULT_CONFIG,
-  {
-    ...DEFAULT_CONFIG,
-    output: {
-      ...DEFAULT_OUTPUT,
-      file: pkg.browser.replace('.js', '.min.js'),
-      format: 'umd',
-    },
-    plugins: [...DEFAULT_CONFIG.plugins, terser()],
-  },
-];
+export default DEFAULT_CONFIG;

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -1,0 +1,17 @@
+import { terser } from 'rollup-plugin-terser';
+import pkg from './package.json';
+import { DEFAULT_CONFIG, DEFAULT_OUTPUT } from './rollup.config';
+
+export default [
+  DEFAULT_CONFIG,
+  {
+    ...DEFAULT_CONFIG,
+    output: {
+      ...DEFAULT_OUTPUT,
+      file: pkg.browser.replace('.js', '.min.js'),
+      format: 'umd',
+    },
+    plugins: [...DEFAULT_CONFIG.plugins],
+    // plugins: [...DEFAULT_CONFIG.plugins, terser()],
+  },
+];

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -2,16 +2,19 @@ import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
 import { DEFAULT_CONFIG, DEFAULT_OUTPUT } from './rollup.config';
 
-export default [
-  DEFAULT_CONFIG,
-  {
-    ...DEFAULT_CONFIG,
-    output: {
-      ...DEFAULT_OUTPUT,
-      file: pkg.browser.replace('.js', '.min.js'),
-      format: 'umd',
-    },
-    plugins: [...DEFAULT_CONFIG.plugins],
-    // plugins: [...DEFAULT_CONFIG.plugins, terser()],
+export default {
+  ...DEFAULT_CONFIG,
+  output: {
+    ...DEFAULT_OUTPUT,
+    file: pkg.browser.replace('.js', '.min.js'),
+    format: 'umd',
   },
-];
+  plugins: [
+    ...DEFAULT_CONFIG.plugins,
+    terser({
+      compress: { passes: 3 },
+      mangle: false,
+      format: { beautify: true },
+    }),
+  ],
+};

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -13,8 +13,6 @@ export default {
     ...DEFAULT_CONFIG.plugins,
     terser({
       compress: { passes: 3 },
-      mangle: false,
-      format: { beautify: true },
     }),
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { bb } from 'billboard.js';
 import React from 'react';
+import propTypes from './propTypes';
 
 function shallowEqual(a, b) {
   const aKeys = Object.keys(a);
@@ -25,6 +26,8 @@ function shallowEqual(a, b) {
 
 class BillboardChart extends React.Component {
   static displayName = 'BillboardChart';
+
+  static propTypes = propTypes;
 
   static getInstances = () => {
     return bb.instance;
@@ -163,10 +166,6 @@ class BillboardChart extends React.Component {
       />
     );
   }
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  BillboardChart.propTypes = require('./propTypes').default;
 }
 
 export default BillboardChart;

--- a/src/propTypes-prod.js
+++ b/src/propTypes-prod.js
@@ -1,0 +1,1 @@
+export default {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,11 @@ babel-plugin-transform-react-remove-prop-types@^0.4.13:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
+babel-plugin-transform-rename-import@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"
+  integrity sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"


### PR DESCRIPTION
## Reason for change

The new build setup in the v2 beta fails because rollup is not handling inline `require` statements correctly.

## Change

Split the build scripts to allow different environments to be used, which ensure `propTypes` can be stripped. Resolves #49 