### PR TITLE
Fix usage example importing CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import React, { Component } from 'react';
 
 // component and styles
 import BillboardChart from 'react-billboardjs';
-import 'react-billboardjs/dist/billboard.css';
+import 'billboard.js/dist/billboard.css';
 
 const CHART_DATA = {
   columns: [


### PR DESCRIPTION
Oops! Usage example was still touting importing from internal CSS when that was removed in v2. Resolves #53 .