### PR TITLE
Update exportChart options

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ this.chartInstance.destroyChart();
 Exports the chart using the functionality introduced in `1.2.0` of `billboard.js` (equivalent to the native [Chart.export](https://naver.github.io/billboard.js/release/latest/doc/Chart.html#export) method).
 
 ```js
-this.chartInstance.exportChart('image/png', (dataUrl) => {
+this.chartInstance.exportChart({ mimeType: 'image/png' }, (dataUrl) => {
   const link = document.createElement('a');
 
   link.download = 'chart.png';

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,12 +1,12 @@
-import '@babel/polyfill';
+import "@babel/polyfill";
 
-import React from 'react';
-import { bb } from 'billboard.js';
-import BillboardChart from '../src/index';
-import { render } from '@testing-library/react';
+import React from "react";
+import { bb } from "billboard.js";
+import BillboardChart from "../src/index";
+import { render } from "@testing-library/react";
 
-jest.mock('billboard.js', () => {
-  const actual = jest.requireActual('billboard.js');
+jest.mock("billboard.js", () => {
+  const actual = jest.requireActual("billboard.js");
 
   return {
     ...actual,
@@ -17,19 +17,19 @@ jest.mock('billboard.js', () => {
   };
 });
 
-describe('react-billboardjs', () => {
+describe("react-billboardjs", () => {
   afterEach(jest.clearAllMocks);
 
-  test('component mount should create a new chart with data', () => {
+  test("component mount should create a new chart with data", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     const { container } = render(
-      <BillboardChart data={data} domProps={domProps} ref={ref} />,
+      <BillboardChart data={data} domProps={domProps} ref={ref} />
     );
 
     const instance = ref.current;
@@ -40,30 +40,30 @@ describe('react-billboardjs', () => {
       bindto: expect.any(HTMLDivElement),
       data,
     });
-    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test('component update should load the new data in the existing chart', () => {
+  test("component update should load the new data in the existing chart", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     const { rerender } = render(
-      <BillboardChart data={data} domProps={domProps} ref={ref} />,
+      <BillboardChart data={data} domProps={domProps} ref={ref} />
     );
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'load');
+    const spy = jest.spyOn(instance.chart, "load");
 
     bb.generate.mockClear();
 
     const nextData = {
       ...data,
-      columns: [...data.columns, ['values', 1, 2, 3, 4, 5, 6]],
+      columns: [...data.columns, ["values", 1, 2, 3, 4, 5, 6]],
     };
 
     rerender(<BillboardChart data={nextData} domProps={domProps} ref={ref} />);
@@ -74,37 +74,37 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('a pure component should only update if the props have changed', () => {
+  test("a pure component should only update if the props have changed", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     const { rerender } = render(
-      <BillboardChart data={data} domProps={domProps} isPure ref={ref} />,
+      <BillboardChart data={data} domProps={domProps} isPure ref={ref} />
     );
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'load');
+    const spy = jest.spyOn(instance.chart, "load");
 
     bb.generate.mockClear();
 
     rerender(
-      <BillboardChart data={data} domProps={domProps} isPure ref={ref} />,
+      <BillboardChart data={data} domProps={domProps} isPure ref={ref} />
     );
 
     expect(spy).not.toHaveBeenCalled();
 
     const nextData = {
       ...data,
-      columns: [...data.columns, ['values', 1, 2, 3, 4, 5, 6]],
+      columns: [...data.columns, ["values", 1, 2, 3, 4, 5, 6]],
     };
 
     rerender(
-      <BillboardChart data={nextData} domProps={domProps} isPure ref={ref} />,
+      <BillboardChart data={nextData} domProps={domProps} isPure ref={ref} />
     );
 
     expect(spy).toHaveBeenCalledWith(nextData);
@@ -112,19 +112,19 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('destroyChart destroy the chart and null it out', () => {
+  test("destroyChart destroy the chart and null it out", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'destroy');
+    const spy = jest.spyOn(instance.chart, "destroy");
 
     instance.destroyChart();
 
@@ -134,45 +134,45 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('exportChart should export the chart as an image', () => {
+  test("exportChart should export the chart as an image", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'export');
+    const spy = jest.spyOn(instance.chart, "export");
     const onExport = jest.fn();
 
-    instance.exportChart('image/png', onExport);
+    instance.exportChart({ mimeType: "image/png" }, onExport);
 
-    expect(spy).toHaveBeenCalledWith('image/png', onExport);
+    expect(spy).toHaveBeenCalledWith({ mimeType: "image/png" }, onExport);
 
     spy.mockRestore();
   });
 
-  test('loadData should load the new data in the chart', () => {
+  test("loadData should load the new data in the chart", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'load');
+    const spy = jest.spyOn(instance.chart, "load");
 
     const nextData = {
       ...data,
-      columns: [...data.columns, ['values', 1, 2, 3, 4, 5, 6]],
+      columns: [...data.columns, ["values", 1, 2, 3, 4, 5, 6]],
     };
 
     instance.loadData(nextData);
@@ -182,19 +182,19 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('redraw should force a flush of the chart', () => {
+  test("redraw should force a flush of the chart", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'flush');
+    const spy = jest.spyOn(instance.chart, "flush");
 
     instance.redraw();
 
@@ -203,22 +203,22 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('unloadData should unload the data in the chart', () => {
+  test("unloadData should unload the data in the chart", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'unload');
+    const spy = jest.spyOn(instance.chart, "unload");
 
     const unloaded = {
-      ids: ['values'],
+      ids: ["values"],
     };
 
     instance.unloadData(unloaded);
@@ -228,34 +228,34 @@ describe('react-billboardjs', () => {
     spy.mockRestore();
   });
 
-  test('updateConfig should update a config setting on the chart', () => {
+  test("updateConfig should update a config setting on the chart", () => {
     const data = {
-      columns: [['values', 30, 20, 50, 40, 60, 50]],
-      type: 'line',
+      columns: [["values", 30, 20, 50, 40, 60, 50]],
+      type: "line",
     };
-    const domProps = { 'data-testid': 'line' };
+    const domProps = { "data-testid": "line" };
     const ref = React.createRef(null);
 
     render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
 
     const instance = ref.current;
 
-    const spy = jest.spyOn(instance.chart, 'config');
+    const spy = jest.spyOn(instance.chart, "config");
 
-    instance.updateConfig('line.max', 100, true);
+    instance.updateConfig("line.max", 100, true);
 
-    expect(spy).toHaveBeenCalledWith('line.max', 100, true);
+    expect(spy).toHaveBeenCalledWith("line.max", 100, true);
 
     spy.mockRestore();
   });
 
-  describe('statics', () => {
-    test('getInstances should return an array of chart instances', () => {
+  describe("statics", () => {
+    test("getInstances should return an array of chart instances", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -268,13 +268,13 @@ describe('react-billboardjs', () => {
     });
   });
 
-  describe('error handling', () => {
-    test('exportChart should notify if the chart does not exist', () => {
+  describe("error handling", () => {
+    test("exportChart should notify if the chart does not exist", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -283,21 +283,21 @@ describe('react-billboardjs', () => {
 
       instance.destroyChart();
 
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      instance.exportChart('image/png', () => {});
+      instance.exportChart({ mimeType: "image/png" }, () => {});
 
-      expect(spy).toHaveBeenCalledWith('No chart is available to export.');
+      expect(spy).toHaveBeenCalledWith("No chart is available to export.");
 
       spy.mockRestore();
     });
 
-    test('loadData should notify if the chart does not exist', () => {
+    test("loadData should notify if the chart does not exist", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -306,28 +306,28 @@ describe('react-billboardjs', () => {
 
       instance.destroyChart();
 
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
       const nextData = {
         ...data,
-        columns: [...data.columns, ['values', 1, 2, 3, 4, 5, 6]],
+        columns: [...data.columns, ["values", 1, 2, 3, 4, 5, 6]],
       };
 
       instance.loadData(nextData);
 
       expect(spy).toHaveBeenCalledWith(
-        'No chart is available to which data can be loaded. It may already have been destroyed, or has never been drawn.',
+        "No chart is available to which data can be loaded. It may already have been destroyed, or has never been drawn."
       );
 
       spy.mockRestore();
     });
 
-    test('redraw should notify if the chart does not exist', () => {
+    test("redraw should notify if the chart does not exist", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -336,21 +336,21 @@ describe('react-billboardjs', () => {
 
       instance.destroyChart();
 
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
       instance.redraw();
 
-      expect(spy).toHaveBeenCalledWith('No chart is available to draw.');
+      expect(spy).toHaveBeenCalledWith("No chart is available to draw.");
 
       spy.mockRestore();
     });
 
-    test('unloadData should notify if the chart does not exist', () => {
+    test("unloadData should notify if the chart does not exist", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -359,27 +359,27 @@ describe('react-billboardjs', () => {
 
       instance.destroyChart();
 
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
       const unloaded = {
-        ids: ['values'],
+        ids: ["values"],
       };
 
       instance.unloadData(unloaded);
 
       expect(spy).toHaveBeenCalledWith(
-        'No chart is available from which data can be unloaded. It may already have been destroyed, or has never been drawn.',
+        "No chart is available from which data can be unloaded. It may already have been destroyed, or has never been drawn."
       );
 
       spy.mockRestore();
     });
 
-    test('updateConfig should notify if the chart does not exist', () => {
+    test("updateConfig should notify if the chart does not exist", () => {
       const data = {
-        columns: [['values', 30, 20, 50, 40, 60, 50]],
-        type: 'line',
+        columns: [["values", 30, 20, 50, 40, 60, 50]],
+        type: "line",
       };
-      const domProps = { 'data-testid': 'line' };
+      const domProps = { "data-testid": "line" };
       const ref = React.createRef(null);
 
       render(<BillboardChart data={data} domProps={domProps} ref={ref} />);
@@ -388,13 +388,13 @@ describe('react-billboardjs', () => {
 
       instance.destroyChart();
 
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-      instance.updateConfig('line.max', 100);
+      instance.updateConfig("line.max", 100);
 
       expect(spy).toHaveBeenCalledWith(
-        'You are trying to set the config a chart that does not exist.' +
-          'Have you passed `data`?',
+        "You are trying to set the config a chart that does not exist." +
+          "Have you passed `data`?"
       );
 
       spy.mockRestore();

--- a/examples/BarChart.js
+++ b/examples/BarChart.js
@@ -49,7 +49,7 @@ class BarChart extends PureComponent {
       setTimeout(() => {
         // this.instance.destroyChart();
 
-        this.instance.exportChart('image/jpeg', (dataUrl) =>
+        this.instance.exportChart({ mimeType: 'image/jpeg' }, (dataUrl) =>
           console.log(dataUrl),
         );
       }, 1000);

--- a/src/index.js
+++ b/src/index.js
@@ -71,13 +71,13 @@ class BillboardChart extends React.Component {
     this.chart = null;
   }
 
-  exportChart(mimeType, onExported) {
+  exportChart(options, onExported) {
     if (!this.chart) {
       // eslint-disable-next-line no-console
       return console.error('No chart is available to export.');
     }
 
-    this.chart.export(mimeType, onExported);
+    this.chart.export(options, onExported);
   }
 
   loadData(data) {


### PR DESCRIPTION
The version of Billboard js' [Chart.export](https://naver.github.io/billboard.js/release/3.0.0/doc/Chart.html#export) used by this repo (3.0.0) as well as latest (3.7.2) expects it's arguments in an object with some optional parameters.  This is a change from some older versions where the only argument was an optional `mimeType` parameter.

I've updated the repo to take this into account, fixing the usage in the readme and the BarChart example.  I've also renamed the parameter from `mimeType` to `options` to hopefully be more clear to callers what its purpose is